### PR TITLE
Added pure Java Uppercase and Junit-based transforms

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -183,6 +183,11 @@
             <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.python</groupId>
+            <artifactId>jython-standalone</artifactId>
+            <version>2.7.2</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/java/src/main/java/com/talend/labs/beam/transforms/python/InvokeViaJythonDoFn.java
+++ b/java/src/main/java/com/talend/labs/beam/transforms/python/InvokeViaJythonDoFn.java
@@ -1,0 +1,51 @@
+package com.talend.labs.beam.transforms.python;
+
+import org.apache.beam.sdk.transforms.DoFn;
+import org.python.core.PyObject;
+import org.python.core.PyUnicode;
+import org.python.util.PythonInterpreter;
+
+import java.io.IOException;
+
+/**
+ * Very primitive way to invoke Python code with Jython, it should be used only for
+ * testing/benchmarking.
+ */
+public class InvokeViaJythonDoFn extends DoFn<String, String> {
+
+  private PythonInterpreter interpreter = null;
+
+  private PyObject pyFn = null;
+
+  private String code = "";
+
+  public InvokeViaJythonDoFn(String code) {
+    this.code = code;
+  }
+
+  @Setup
+  public void setup() throws Exception {
+    interpreter = new PythonInterpreter();
+    String userData = setUpMap();
+    interpreter.exec(userData);
+    pyFn = interpreter.get("userFunction");
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext context) throws IOException {
+    PyObject output = pyFn.__call__(new PyUnicode(context.element()));
+    context.output(output.toString());
+  }
+
+  private String setUpMap() {
+    return ""
+            + "def userFunction(input):\n" //
+            + "  " + code.replaceAll("\n", "\n  ").trim() + "\n"//
+            + "  return output\n"; //
+  }
+
+  @Teardown
+  public void tearDown() {
+    interpreter.close();
+  }
+}


### PR DESCRIPTION
Run pure Java Uppercase pipeline (no Python transforms):
```
mvn compile exec:java -Dexec.mainClass=com.talend.labs.beam.transforms.python.examples.Uppercase -Dexec.args="--inputPath=/path/to/city_temperature.csv --usePython=false"
```

Run Uppercase pipeline with Python transform via Jython:
```
mvn compile exec:java -Dexec.mainClass=com.talend.labs.beam.transforms.python.examples.Uppercase -Dexec.args="--inputPath=/path/to/city_temperature.csv"
```

Run Uppercase pipeline with Python transform via Lucidoitdoit server:
```
mvn compile exec:java -Dexec.mainClass=com.talend.labs.beam.transforms.python.examples.Uppercase -Dexec.args="--inputPath=/path/to/city_temperature.csv --serverInvokerPat=/path/to/lucisetup"
```
